### PR TITLE
Not using SA operators for SA analysis should be a fatal error

### DIFF
--- a/src/beast/evolution/speciation/SABirthDeathModel.java
+++ b/src/beast/evolution/speciation/SABirthDeathModel.java
@@ -173,7 +173,7 @@ public class SABirthDeathModel extends SpeciesTreeDistribution {
         				}
         			}        		 	
         			if (!isOK) {
-        				Log.err.println("ERROR: " + op.getClass().getSimpleName() + 
+                        throw new RuntimeException("ERROR: " + op.getClass().getSimpleName() +
         						" is not a valid operator for a sampled ancestor analysis.\n" + 
         						"Either remove the operator (id=" + op.getID() + ") or fix the " +
         					    "removal probability to 1.0 so this is not a sampled ancestor " +


### PR DESCRIPTION
Current behaviour when running a sampled ancestors analysis without using sampled ancestor tree operators is to print an error message stating the analysis is not valid and continue running. The error message is printed in between other initialisation output and will probably not be noticed by many users. If the analysis is not valid the error should be fatal and the program should refuse to run.