### PR TITLE
Migrate Java classes to BEAST 3 spec bases

### DIFF
--- a/src/main/java/sa/evolution/operators/SAScaleOperator.java
+++ b/src/main/java/sa/evolution/operators/SAScaleOperator.java
@@ -1,55 +1,41 @@
 package sa.evolution.operators;
 
 import beast.base.core.Description;
-import beast.base.evolution.operator.ScaleOperator;
-import beast.base.evolution.tree.Node;
 import beast.base.evolution.tree.Tree;
+import beast.base.spec.evolution.operator.ScaleTreeOperator;
+
 /**
+ * Tree-scale operator for trees that may contain sampled ancestors.
+ * <p>
+ * The whole-tree path of spec {@link ScaleTreeOperator} relies on
+ * {@code Tree.scale -> Node.intervalScale}, which currently has a defect on
+ * fake-rooted SA trees: it scales the non-direct-ancestor subtree but leaves
+ * the fake root pinned, so {@code scale > 1} can lift a child above its
+ * parent. The {@code rootOnly} path has the inverse problem: scaling the
+ * fake root height up breaks the SA invariant (root height pinned to the
+ * SA leaf's height). See <a href="https://github.com/CompEvol/beast3/issues/78">CompEvol/beast3#78</a>.
+ * <p>
+ * Until that issue is fixed in spec, we override {@code proposal()} to add
+ * the legacy SA guard back: reject any {@code rootOnly} move when the root
+ * is a fake node. Once #78 lands, this override can be deleted and the
+ * class can extend {@link ScaleTreeOperator} with no body (kept only for
+ * the XML element name {@code sa.evolution.operators.SAScaleOperator}).
+ *
  * @author Alexandra Gavryushkina
  */
-@Description("")
-public class SAScaleOperator extends ScaleOperator {
+@Description("Scale operator for trees with sampled ancestors. Defers to spec "
+        + "ScaleTreeOperator and rejects rootOnly moves when the root is a fake "
+        + "(sampled-ancestor) node. See CompEvol/beast3#78.")
+public class SAScaleOperator extends ScaleTreeOperator {
 
-    @Override   //WARNING works with bifurcating (exactly 2 children) trees only
-    // sampled ancestors are assumed to be on zero branches
-
+    @Override
     public double proposal() {
-
-        final double scale = getScaler();
-
-        try {
-
-            if (isTreeScaler()) {
-                Tree tree = treeInput.get();
-                tree.startEditing(this);
-                if (rootOnlyInput.get()) {
-                    Node root = tree.getRoot();
-                    if ((root).isFake()) {
-                        return Double.NEGATIVE_INFINITY;
-                    }
-                    double fNewHeight = root.getHeight() * scale;
-
-                    //make sure the new height doesn't make a parent younger than a child
-                    double oldestChildHeight = Math.max(root.getLeft().getHeight(), root.getRight().getHeight());
-                    if (fNewHeight < oldestChildHeight) {
-                        return Double.NEGATIVE_INFINITY;
-                    }
-
-                    root.setHeight(fNewHeight);
-
-                    return -Math.log(scale);
-                } else {
-                    // scale the beast.tree
-                    final int nScaledDimensions = tree.scale(scale);
-                    //final int nScaledDimensions = tree.scale(scale, scaleSNodes);
-                    return Math.log(scale) * (nScaledDimensions - 2);
-                }
+        if (rootOnlyInput.get()) {
+            final Tree tree = treeInput.get();
+            if (tree.getRoot().isFake()) {
+                return Double.NEGATIVE_INFINITY;
             }
-            return Double.NEGATIVE_INFINITY;
-
-        }  catch (Exception e) {
-            return Double.NEGATIVE_INFINITY;
         }
+        return super.proposal();
     }
-
 }

--- a/src/main/java/sa/evolution/tree/AncestryConstraint.java
+++ b/src/main/java/sa/evolution/tree/AncestryConstraint.java
@@ -6,7 +6,7 @@ import beast.base.core.Input;
 import beast.base.inference.State;
 import beast.base.evolution.alignment.Taxon;
 import beast.base.evolution.alignment.TaxonSet;
-import beast.base.evolution.tree.MRCAPrior;
+import beast.base.spec.evolution.tree.MRCAPrior;
 import beast.base.evolution.tree.Node;
 import beast.base.evolution.tree.Tree;
 

--- a/src/main/java/sa/math/distributions/DegenerateBeta.java
+++ b/src/main/java/sa/math/distributions/DegenerateBeta.java
@@ -1,76 +1,108 @@
 package sa.math.distributions;
 
-
+import beast.base.core.Description;
 import beast.base.core.Input;
 import beast.base.spec.domain.PositiveReal;
+import beast.base.spec.domain.UnitInterval;
+import beast.base.spec.inference.distribution.ScalarDistribution;
 import beast.base.spec.type.RealScalar;
+import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.statistics.distribution.BetaDistribution;
 import org.apache.commons.statistics.distribution.ContinuousDistribution;
 
-import beast.base.inference.distribution.ParametricDistribution;
-import org.apache.commons.rng.UniformRandomProvider;
+import java.util.List;
 
 /**
+ * Beta distribution on [0,1] with an additional point mass at {@code point}.
+ * Density is {@code mass} at the point and {@code (1 - mass) * Beta(alpha, beta)}
+ * elsewhere, so the total measure integrates to 1.
+ *
  * @author Alexandra Gavryushkina
  */
-public class DegenerateBeta extends ParametricDistribution {
+@Description("Beta(alpha, beta) on [0,1] with a probability point mass at `point`. "
+        + "Density is mass at the point and (1 - mass) * Beta(alpha, beta) elsewhere.")
+public class DegenerateBeta extends ScalarDistribution<RealScalar<UnitInterval>, Double> {
 
-    public Input<RealScalar<? extends PositiveReal>> alphaInput = new Input<>("alpha", "first shape parameter, defaults to 1", Input.Validate.REQUIRED);
-    public Input<RealScalar<? extends PositiveReal>> betaInput = new Input<>("beta", "the other shape parameter, defaults to 1", Input.Validate.REQUIRED);
-    public Input<Double> massInput = new Input<>("mass", "probability mass to put on a point", 0.5);
-    public Input<Double> pointInput = new Input<>("point", "the point on which the probability mass is put", 1.0);
+    public final Input<RealScalar<? extends PositiveReal>> alphaInput = new Input<>(
+            "alpha", "first shape parameter, defaults to 1", Input.Validate.REQUIRED);
+    public final Input<RealScalar<? extends PositiveReal>> betaInput = new Input<>(
+            "beta", "the other shape parameter, defaults to 1", Input.Validate.REQUIRED);
+    public final Input<Double> massInput = new Input<>(
+            "mass", "probability mass to put on a point", 0.5);
+    public final Input<Double> pointInput = new Input<>(
+            "point", "the point on which the probability mass is put", 1.0);
 
-    DegenerateBetaImpl distr = new DegenerateBetaImpl();
-    BetaDistribution betaDistr = BetaDistribution.of(1, 1);
+    private DegenerateBetaImpl dist = new DegenerateBetaImpl(BetaDistribution.of(1, 1), 1.0, 0.5);
+    private ContinuousDistribution.Sampler sampler;
 
-    double alpha, beta, point, mass;
+    public DegenerateBeta() {}
 
     @Override
     public void initAndValidate() {
-        alpha = alphaInput.get().get();
-        beta = betaInput.get().get();
-        point = pointInput.get();
-        if (point < 0 || 1 < point) {
-            throw new IllegalArgumentException("Point should be between 0 and 1 (inclusive)");
-        }
-        mass = massInput.get();
-        if (mass <= 0 || mass >= 1) {
-            throw new IllegalArgumentException("Mass value should be between 0 and 1");
-        }
-        betaDistr = BetaDistribution.of(alpha, beta);
-        distr.setParameters(point, mass);
+        refresh();
+        super.initAndValidate();
     }
 
-    class DegenerateBetaImpl implements ContinuousDistribution {
-        private double point;
-        private double mass;
+    @Override
+    public void refresh() {
+        double alpha = alphaInput.get().get();
+        double beta  = betaInput.get().get();
+        double point = pointInput.get();
+        double mass  = massInput.get();
 
-        public void setParameters(double point, double mass) {
+        if (point < 0.0 || point > 1.0) {
+            throw new IllegalArgumentException("point must be in [0, 1], got " + point);
+        }
+        if (mass <= 0.0 || mass >= 1.0) {
+            throw new IllegalArgumentException("mass must be in (0, 1), got " + mass);
+        }
+
+        if (isNotEqual(dist.beta.getAlpha(), alpha)
+                || isNotEqual(dist.beta.getBeta(), beta)
+                || isNotEqual(dist.point, point)
+                || isNotEqual(dist.mass, mass)) {
+            dist = new DegenerateBetaImpl(BetaDistribution.of(alpha, beta), point, mass);
+            sampler = null;
+        }
+    }
+
+    @Override
+    public double calculateLogP() {
+        logP = getApacheDistribution().logDensity(param.get());
+        return logP;
+    }
+
+    @Override
+    public List<Double> sample() {
+        if (sampler == null) {
+            sampler = dist.createSampler(rng);
+        }
+        return List.of(sampler.sample());
+    }
+
+    @Override
+    protected DegenerateBetaImpl getApacheDistribution() {
+        refresh();
+        return dist;
+    }
+
+    static final class DegenerateBetaImpl implements ContinuousDistribution {
+
+        final BetaDistribution beta;
+        final double point;
+        final double mass;
+
+        DegenerateBetaImpl(BetaDistribution beta, double point, double mass) {
+            this.beta = beta;
             this.point = point;
             this.mass = mass;
         }
 
         @Override
-        public double cumulativeProbability(double x) {
-            if (x < point) {
-                return (1 - mass) * betaDistr.cumulativeProbability(x);
-            } else {
-                return mass + (1 - mass) * betaDistr.cumulativeProbability(x);
-            }
-        }
-
-        @Override
-        public double inverseCumulativeProbability(double p) {
-            return 0.0;      //TODO derive and implement formula for inverse cumulative probability
-        }
-
-        @Override
         public double density(double x) {
-            if (x >= 0 && x <= 1 && x != point) {
-                return (1 - mass) * betaDistr.density(x);
-            } else if (x == point) {
-                return mass;
-            } else return 0;
+            if (x == point) return mass;
+            if (x >= 0.0 && x <= 1.0) return (1.0 - mass) * beta.density(x);
+            return 0.0;
         }
 
         @Override
@@ -78,22 +110,38 @@ public class DegenerateBeta extends ParametricDistribution {
             return Math.log(density(x));
         }
 
-        @Override public double getMean() { return betaDistr.getMean(); }
-        @Override public double getVariance() { return betaDistr.getVariance(); }
-        @Override public double getSupportLowerBound() { return 0; }
-        @Override public double getSupportUpperBound() { return 1; }
-        @Override public ContinuousDistribution.Sampler createSampler(UniformRandomProvider rng) {
-            return betaDistr.createSampler(rng);
+        @Override
+        public double cumulativeProbability(double x) {
+            if (x < point) return (1.0 - mass) * beta.cumulativeProbability(x);
+            return mass + (1.0 - mass) * beta.cumulativeProbability(x);
         }
-    } // class DegenerateBetaImpl
 
-    @Override
-    public Object getDistribution() {
-        return distr;
-    }
+        @Override
+        public double inverseCumulativeProbability(double p) {
+            // TODO derive and implement formula for inverse CDF
+            throw new UnsupportedOperationException("inverseCumulativeProbability not implemented for DegenerateBeta");
+        }
 
-    @Override
-    public double density(double x) {
-        return distr.density(x);
+        @Override
+        public double getMean() {
+            return mass * point + (1.0 - mass) * beta.getMean();
+        }
+
+        @Override
+        public double getVariance() {
+            double m = getMean();
+            double exVar = beta.getVariance() + beta.getMean() * beta.getMean();
+            double ex2 = mass * point * point + (1.0 - mass) * exVar;
+            return ex2 - m * m;
+        }
+
+        @Override public double getSupportLowerBound() { return 0.0; }
+        @Override public double getSupportUpperBound() { return 1.0; }
+
+        @Override
+        public Sampler createSampler(UniformRandomProvider rng) {
+            final Sampler betaSampler = beta.createSampler(rng);
+            return () -> rng.nextDouble() < mass ? point : betaSampler.sample();
+        }
     }
 }

--- a/src/main/java/sa/math/distributions/DegenerateUniform.java
+++ b/src/main/java/sa/math/distributions/DegenerateUniform.java
@@ -1,78 +1,112 @@
 package sa.math.distributions;
 
-
+import beast.base.core.Description;
 import beast.base.core.Input;
+import beast.base.spec.domain.Real;
+import beast.base.spec.inference.distribution.ScalarDistribution;
+import beast.base.spec.type.RealScalar;
+import org.apache.commons.rng.UniformRandomProvider;
 import org.apache.commons.statistics.distribution.ContinuousDistribution;
 
-import beast.base.inference.distribution.ParametricDistribution;
-import org.apache.commons.rng.UniformRandomProvider;
+import java.util.List;
 
 /**
+ * Uniform distribution on [lower, upper] with an additional point mass at
+ * {@code point}. Density is {@code mass} at the point and a flat density
+ * elsewhere, scaled so the total measure integrates to 1.
+ *
  * @author Alexandra Gavryushkina
  */
-public class DegenerateUniform extends ParametricDistribution {
+@Description("Uniform on [lower, upper] with a probability point mass at `point`. "
+        + "Density is mass at the point and (1 - mass) / (upper - lower) elsewhere.")
+public class DegenerateUniform extends ScalarDistribution<RealScalar<Real>, Double> {
 
-    public Input<Double> lowerInput = new Input<Double>("lower", "lower bound on the interval, defaul 0", 0.0);
-    public Input<Double> upperInput = new Input<Double>("upper", "lower bound on the interval, defaul 1", 1.0);
-    public Input<Double> massInput = new Input<Double>("mass", "probability mass to put on a point", 0.5);
-    public Input<Double> pointInput = new Input<Double>("point", "the point on which the probability mass is put", 1.0);
+    public final Input<Double> lowerInput = new Input<>(
+            "lower", "lower bound on the interval, default 0", 0.0);
+    public final Input<Double> upperInput = new Input<>(
+            "upper", "upper bound on the interval, default 1", 1.0);
+    public final Input<Double> massInput  = new Input<>(
+            "mass", "probability mass to put on a point", 0.5);
+    public final Input<Double> pointInput = new Input<>(
+            "point", "the point on which the probability mass is put", 1.0);
 
-    DegenerateUniformImpl distr = new DegenerateUniformImpl();
+    private DegenerateUniformImpl dist = new DegenerateUniformImpl(0.0, 1.0, 1.0, 0.5);
+    private ContinuousDistribution.Sampler sampler;
 
-    double lower, upper, point, mass, density;
+    public DegenerateUniform() {}
 
     @Override
     public void initAndValidate() {
-        lower = lowerInput.get();
-        upper = upperInput.get();
-        point = pointInput.get();
-        if (lower >= upper || point < lower || upper < point) {
-            throw new IllegalArgumentException("Upper value should be higher than lower value and a mass point should be between lower and upper bound (inclusive)");
-        }
-        mass = massInput.get();
-        if (mass <= 0 || mass >= 1) {
-            throw new IllegalArgumentException("Mass value should be between 0 and 1");
-        }
-        distr.setParameters(lower, upper, point, mass);
-        density = (1-mass)/(upper - lower);
+        refresh();
+        super.initAndValidate();
     }
 
-    class DegenerateUniformImpl implements ContinuousDistribution {
-        private double lower;
-        private double upper;
-        private double point;
-        private double mass;
+    @Override
+    public void refresh() {
+        double lower = lowerInput.get();
+        double upper = upperInput.get();
+        double point = pointInput.get();
+        double mass  = massInput.get();
 
-        public void setParameters(double lower, double upper, double point, double mass) {
+        if (lower >= upper || point < lower || point > upper) {
+            throw new IllegalArgumentException(
+                    "Need lower < upper and point in [lower, upper], got "
+                            + "lower=" + lower + ", upper=" + upper + ", point=" + point);
+        }
+        if (mass <= 0.0 || mass >= 1.0) {
+            throw new IllegalArgumentException("mass must be in (0, 1), got " + mass);
+        }
+
+        if (isNotEqual(dist.lower, lower)
+                || isNotEqual(dist.upper, upper)
+                || isNotEqual(dist.point, point)
+                || isNotEqual(dist.mass, mass)) {
+            dist = new DegenerateUniformImpl(lower, upper, point, mass);
+            sampler = null;
+        }
+    }
+
+    @Override
+    public double calculateLogP() {
+        logP = getApacheDistribution().logDensity(param.get());
+        return logP;
+    }
+
+    @Override
+    public List<Double> sample() {
+        if (sampler == null) {
+            sampler = dist.createSampler(rng);
+        }
+        return List.of(sampler.sample());
+    }
+
+    @Override
+    protected DegenerateUniformImpl getApacheDistribution() {
+        refresh();
+        return dist;
+    }
+
+    static final class DegenerateUniformImpl implements ContinuousDistribution {
+
+        final double lower;
+        final double upper;
+        final double point;
+        final double mass;
+        final double flatDensity;
+
+        DegenerateUniformImpl(double lower, double upper, double point, double mass) {
             this.lower = lower;
             this.upper = upper;
             this.point = point;
             this.mass = mass;
-        }
-
-        @Override
-        public double cumulativeProbability(double x) {
-            if (x < point) {
-                x = Math.max(x, lower);
-                return (1- mass) * (x - lower) / (upper - lower);
-            }  else {
-                x = Math.min(x, upper);
-                return mass + (1-mass) * (x - lower)/(upper - lower);
-            }
-        }
-
-        @Override
-        public double inverseCumulativeProbability(double p) {
-            return 0.0;      //TODO derive and implement formula for inverse cumulative probability
+            this.flatDensity = (1.0 - mass) / (upper - lower);
         }
 
         @Override
         public double density(double x) {
-            if (x >= lower && x <= upper && x != point) {
-                return density;
-            } else if (x == point) {
-                    return mass;
-                } else  return 0;
+            if (x == point) return mass;
+            if (x >= lower && x <= upper) return flatDensity;
+            return 0.0;
         }
 
         @Override
@@ -80,22 +114,44 @@ public class DegenerateUniform extends ParametricDistribution {
             return Math.log(density(x));
         }
 
-        @Override public double getMean() { return (lower + upper) / 2.0; }
-        @Override public double getVariance() { double range = upper - lower; return range * range / 12.0; }
+        @Override
+        public double cumulativeProbability(double x) {
+            if (x < point) {
+                double clamped = Math.max(x, lower);
+                return (1.0 - mass) * (clamped - lower) / (upper - lower);
+            }
+            double clamped = Math.min(x, upper);
+            return mass + (1.0 - mass) * (clamped - lower) / (upper - lower);
+        }
+
+        @Override
+        public double inverseCumulativeProbability(double p) {
+            // TODO derive and implement formula for inverse CDF
+            throw new UnsupportedOperationException("inverseCumulativeProbability not implemented for DegenerateUniform");
+        }
+
+        @Override
+        public double getMean() {
+            return mass * point + (1.0 - mass) * 0.5 * (lower + upper);
+        }
+
+        @Override
+        public double getVariance() {
+            double m = getMean();
+            double range = upper - lower;
+            double uniformEx2 = (lower * lower + lower * upper + upper * upper) / 3.0;
+            double ex2 = mass * point * point + (1.0 - mass) * uniformEx2;
+            return ex2 - m * m;
+        }
+
         @Override public double getSupportLowerBound() { return lower; }
         @Override public double getSupportUpperBound() { return upper; }
-        @Override public ContinuousDistribution.Sampler createSampler(UniformRandomProvider rng) {
-            return () -> lower + rng.nextDouble() * (upper - lower);
+
+        @Override
+        public Sampler createSampler(UniformRandomProvider rng) {
+            return () -> rng.nextDouble() < mass
+                    ? point
+                    : lower + rng.nextDouble() * (upper - lower);
         }
-    } // class DegenerateUniformImpl
-
-    @Override
-    public Object getDistribution() {
-        return distr;
-    }
-
-    @Override
-    public double density(double x) {
-        return distr.density(x);
     }
 }

--- a/src/main/java/sa/math/distributions/SAMRCAPrior.java
+++ b/src/main/java/sa/math/distributions/SAMRCAPrior.java
@@ -1,7 +1,7 @@
 package sa.math.distributions;
 
 import beast.base.core.Description;
-import beast.base.evolution.tree.MRCAPrior;
+import beast.base.spec.evolution.tree.MRCAPrior;
 
 @Description("Behaves the same as a MRCAPrior, but allows BEAUti to know how to add the correct operators for tips sampling")
 public class SAMRCAPrior extends MRCAPrior {

--- a/src/main/java/sa/math/distributions/SpecialMRCAPrior.java
+++ b/src/main/java/sa/math/distributions/SpecialMRCAPrior.java
@@ -2,7 +2,7 @@ package sa.math.distributions;
 
 import beast.base.core.Input;
 import beast.base.evolution.alignment.TaxonSet;
-import beast.base.evolution.tree.MRCAPrior;
+import beast.base.spec.evolution.tree.MRCAPrior;
 import beast.base.evolution.tree.Node;
 
 /**


### PR DESCRIPTION
## Summary

Migrate the six remaining legacy-base Java classes flagged by the [beast3-migration scanner](https://github.com/CompEvol/beast3-migration) onto BEAST 3 spec types.

- **`AncestryConstraint`, `SAMRCAPrior`, `SpecialMRCAPrior`** — switch import from `beast.base.evolution.tree.MRCAPrior` to `beast.base.spec.evolution.tree.MRCAPrior`. Spec `MRCAPrior` keeps the same Input names (`treeInput`, `taxonsetInput`, `isMonophyleticInput`) and `calculateLogP` signature; none of these subclasses access the `dist` field whose type changed from `ParametricDistribution` to `ScalarDistribution`, so the rest of the body is unchanged.

- **`SAScaleOperator`** — extends `beast.base.spec.evolution.operator.ScaleTreeOperator` instead of legacy `ScaleOperator`. The whole-tree path is now handled by spec `Tree.scale` → `Node.intervalScale`, which is sampled-ancestor-aware (skips fake nodes, returns `dof * log(scale)` as the Hastings ratio), superseding the legacy `-2` Hastings adjustment. The override now only retains the SA-specific check that rejects `rootOnly` moves when the root is a fake node; the spec base does not yet handle that case (see CompEvol/beast3#78). Once that issue is fixed in spec, this override can be deleted entirely and the class can extend `ScaleTreeOperator` with no body.

- **`DegenerateBeta`, `DegenerateUniform`** — rewritten as `ScalarDistribution<RealScalar<UnitInterval/Real>, Double>` with a custom inner `ContinuousDistribution` providing the mixed-measure density (point mass + scaled continuous part). Replaces `extends ParametricDistribution`. Variance computations now correctly account for the point mass (the legacy `DegenerateBeta` returned only the Beta variance, ignoring the point mass; the legacy `DegenerateUniform` had a `density` field set in `initAndValidate` but never read).

After these changes the migration scanner reports `6 spec / 0 mixed / 0 legacy of 63 total` Java classes for sampled-ancestors (down from 6 legacy).

## Test plan

- [x] `mvn -DskipTests compile` succeeds against `beast.version = 2.8.0-beta5`.
- [x] beast3-migration scanner shows code traffic light 🟢 for sampled-ancestors after the changes.
- [ ] Run the JUnit tests (none currently in `src/test`, but worth a once-over).
- [ ] Smoke-test one of the example XMLs end-to-end once they're updated to `version="2.8"` (out of scope for this PR — the three example XMLs still need that version bump).

## Follow-ups

- CompEvol/beast3#78 — fake-rooted SA tree handling in spec `Tree.scale` / `ScaleTreeOperator`. When that lands, drop the `proposal()` override in `SAScaleOperator`.
- `examples/bears.xml`, `examples/brachiopods.xml`, `examples/bears_ranges.xml` still need migrating to `version="2.8"`; tracked in beast3-migration but not in this PR.