### PR TITLE
Migrate example XMLs to BEAST 3 spec

### DIFF
--- a/examples/bears.xml
+++ b/examples/bears.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><beast beautitemplate='Standard' beautistatus='' namespace="beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.alignment:beast.base.evolution.tree.coalescent:beast.pkgmgmt:beast.base.core:beast.base.inference.util:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.base.spec.inference.parameter" version="2.0">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><beast beautitemplate='Standard' beautistatus='' namespace="beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.alignment:beast.base.evolution.tree.coalescent:beast.pkgmgmt:beast.base.core:beast.base.inference.util:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.base.spec.inference.parameter:beast.base.spec.domain" version="2.8">
 
 
     <data
@@ -48,16 +48,6 @@ name="alignment">
 
 
     
-<map name="Uniform">beast.base.inference.distribution.Uniform</map>
-<map name="Exponential">beast.base.inference.distribution.Exponential</map>
-<map name="LogNormal">beast.base.inference.distribution.LogNormalDistributionModel</map>
-<map name="Normal">beast.base.inference.distribution.Normal</map>
-<map name="Beta">beast.base.inference.distribution.Beta</map>
-<map name="Gamma">beast.base.inference.distribution.Gamma</map>
-<map name="LaplaceDistribution">beast.base.inference.distribution.LaplaceDistribution</map>
-<map name="prior">beast.base.inference.distribution.Prior</map>
-<map name="InverseGamma">beast.base.inference.distribution.InverseGamma</map>
-<map name="OneOnX">beast.base.inference.distribution.OneOnX</map>
 
 
 <run id="mcmc" spec="MCMC" chainLength="10000000">
@@ -103,18 +93,18 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
             </trait>
             <taxonset idref="TaxonSet.bears"/>
         </tree>
-        <parameter id="ucldMean.c:bears" name="stateNode">1.0</parameter>
-        <parameter id="ucldStdev.c:bears" lower="0.0" name="stateNode">0.1</parameter>
-        <stateNode id="rateCategories.c:bears" spec="parameter.IntegerParameter" dimension="66">1</stateNode>
+        <stateNode id="ucldMean.c:bears" spec="RealScalarParam" domain="PositiveReal" value="1.0"/>
+        <stateNode id="ucldStdev.c:bears" spec="RealScalarParam" domain="PositiveReal" value="0.1"/>
+        <stateNode id="rateCategories.c:bears" spec="IntVectorParam" domain="NonNegativeInt" dimension="66" value="1"/>
         <stateNode id="originFBD.t:bears" spec="RealScalarParam" domain="PositiveReal" value="100.0"/>
         <stateNode id="diversificationRateFBD.t:bears" spec="RealScalarParam" domain="Real" value="1.0"/>
         <stateNode id="turnoverFBD.t:bears" spec="RealScalarParam" domain="UnitInterval" value="0.5"/>
         <stateNode id="samplingProportionFBD.t:bears" spec="RealScalarParam" domain="UnitInterval" value="0.5"/>
     </state>
 
-    <init id="RandomTree.t:bears" spec="beast.base.evolution.tree.coalescent.RandomTree" estimate="false" initial="@Tree.t:bears" taxa="@bears">
+    <init id="RandomTree.t:bears" spec="beast.base.spec.evolution.tree.coalescent.RandomTree" estimate="false" initial="@Tree.t:bears" taxa="@bears">
         <populationModel id="ConstantPopulation0.t:bears" spec="ConstantPopulation">
-            <parameter id="randomPopSize.t:bears" name="popSize">1.0</parameter>
+            <popSize id="randomPopSize.t:bears" spec="RealScalarParam" domain="PositiveReal" value="1.0"/>
         </populationModel>
     </init>
 
@@ -132,16 +122,14 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
             </distribution>
             <distribution id="samplingProportionPriorFBD.t:bears" spec="beast.base.spec.inference.distribution.Uniform" param="@samplingProportionFBD.t:bears"/>
             <distribution id="turnoverPriorFBD.t:bears" spec="beast.base.spec.inference.distribution.Uniform" param="@turnoverFBD.t:bears"/>
-            <prior id="MeanRatePrior.c:bears" name="distribution" x="@ucldMean.c:bears">
-                <Uniform id="Uniform.04" name="distr" upper="Infinity"/>
-            </prior>
-            <prior id="ucldStdevPrior.c:bears" name="distribution" x="@ucldStdev.c:bears">
-                <Gamma id="Gamma.0" name="distr">
-                    <parameter id="RealParameter.0" estimate="false" name="alpha">0.5396</parameter>
-                    <parameter id="RealParameter.01" estimate="false" name="beta">0.3819</parameter>
-                </Gamma>
-            </prior>
-            <distribution id="Canidae.prior" spec="beast.base.evolution.tree.MRCAPrior" monophyletic="true" tree="@Tree.t:bears">
+            <distribution id="MeanRatePrior.c:bears" spec="beast.base.spec.inference.distribution.Uniform" param="@ucldMean.c:bears">
+                <upper spec="RealScalarParam" domain="Real" value="10000.0" estimate="false"/>
+            </distribution>
+            <distribution id="ucldStdevPrior.c:bears" spec="beast.base.spec.inference.distribution.Gamma" param="@ucldStdev.c:bears">
+                <alpha spec="RealScalarParam" domain="PositiveReal" value="0.5396" estimate="false"/>
+                <beta spec="RealScalarParam" domain="PositiveReal" value="0.3819" estimate="false"/>
+            </distribution>
+            <distribution id="Canidae.prior" spec="beast.base.spec.evolution.tree.MRCAPrior" monophyletic="true" tree="@Tree.t:bears">
                 <taxonset id="Canidae" spec="TaxonSet">
                     <taxon id="Canis_lupus_0.0" spec="Taxon"/>
                     <taxon id="Caedocyon_tedfordi_25.88" spec="Taxon"/>
@@ -160,10 +148,10 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
                     <parameter id="proportionInvariant.s:bears" estimate="false" lower="0.0" name="proportionInvariant" upper="1.0">0.0</parameter>
                     <substModel id="JC69.s:bears" spec="JukesCantor"/>
                 </siteModel>
-                <branchRateModel id="RelaxedClock.c:bears" spec="beast.base.evolution.branchratemodel.UCRelaxedClockModel" clock.rate="@ucldMean.c:bears" rateCategories="@rateCategories.c:bears" tree="@Tree.t:bears">
-                    <LogNormal id="LogNormalDistributionModel.c:bears" S="@ucldStdev.c:bears" meanInRealSpace="true" name="distr">
-                        <parameter id="RealParameter.02" estimate="false" lower="0.0" name="M" upper="1.0">1.0</parameter>
-                    </LogNormal>
+                <branchRateModel id="RelaxedClock.c:bears" spec="beast.base.spec.evolution.branchratemodel.UCRelaxedClockModel" clock.rate="@ucldMean.c:bears" rateCategories="@rateCategories.c:bears" tree="@Tree.t:bears">
+                    <distribution id="LogNormalDistributionModel.c:bears" spec="beast.base.spec.inference.distribution.LogNormal" S="@ucldStdev.c:bears" meanInRealSpace="true" name="distr">
+                        <M spec="RealScalarParam" domain="Real" value="1.0" estimate="false"/>
+                    </distribution>
                 </branchRateModel>
             </distribution>
         </distribution>
@@ -177,7 +165,7 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
 
     <operator id="CategoriesSwapOperator.c:bears" spec="SwapOperator" intparameter="@rateCategories.c:bears" weight="10.0"/>
 
-    <operator id="CategoriesUniform.c:bears" spec="UniformOperator" parameter="@rateCategories.c:bears" weight="10.0"/>
+    <operator id="CategoriesUniform.c:bears" spec="beast.base.spec.inference.operator.uniform.IntUniformOperator" parameter="@rateCategories.c:bears" weight="10.0"/>
 
     <operator id="relaxedUpDownOperator.c:bears" spec="UpDownOperator" scaleFactor="0.75" weight="3.0">
         <up idref="ucldMean.c:bears"/>
@@ -232,7 +220,7 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
     </logger>
 
     <logger id="treelog.t:bears" fileName="$(tree).trees" logEvery="1000" mode="tree">
-        <log id="TreeWithMetaDataLogger.t:bears" spec="beast.base.evolution.TreeWithMetaDataLogger" branchratemodel="@RelaxedClock.c:bears" tree="@Tree.t:bears"/>
+        <log id="TreeWithMetaDataLogger.t:bears" spec="beast.base.spec.evolution.TreeWithMetaDataLogger" branchratemodel="@RelaxedClock.c:bears" tree="@Tree.t:bears"/>
     </logger>
 
 </run>

--- a/examples/bears_ranges.xml
+++ b/examples/bears_ranges.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><beast beautitemplate='Standard' beautistatus='' namespace="beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.alignment:beast.base.evolution.tree.coalescent:beast.pkgmgmt:beast.base.core:beast.base.inference.util:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.base.spec.inference.parameter" version="2.0">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><beast beautitemplate='Standard' beautistatus='' namespace="beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.alignment:beast.base.evolution.tree.coalescent:beast.pkgmgmt:beast.base.core:beast.base.inference.util:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.base.spec.inference.parameter:beast.base.spec.domain" version="2.8">
 
 
     <data
@@ -48,16 +48,6 @@ name="alignment">
 
 
     
-<map name="Uniform">beast.base.inference.distribution.Uniform</map>
-<map name="Exponential">beast.base.inference.distribution.Exponential</map>
-<map name="LogNormal">beast.base.inference.distribution.LogNormalDistributionModel</map>
-<map name="Normal">beast.base.inference.distribution.Normal</map>
-<map name="Beta">beast.base.inference.distribution.Beta</map>
-<map name="Gamma">beast.base.inference.distribution.Gamma</map>
-<map name="LaplaceDistribution">beast.base.inference.distribution.LaplaceDistribution</map>
-<map name="prior">beast.base.inference.distribution.Prior</map>
-<map name="InverseGamma">beast.base.inference.distribution.InverseGamma</map>
-<map name="OneOnX">beast.base.inference.distribution.OneOnX</map>
 
 
 <run id="mcmc" spec="MCMC" chainLength="10000000">
@@ -103,18 +93,18 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
             </trait>
             <taxonset idref="TaxonSet.bears"/>
         </tree>
-        <parameter id="ucldMean.c:bears" name="stateNode">1.0</parameter>
-        <parameter id="ucldStdev.c:bears" lower="0.0" name="stateNode">0.1</parameter>
-        <stateNode id="rateCategories.c:bears" spec="parameter.IntegerParameter" dimension="66">1</stateNode>
+        <stateNode id="ucldMean.c:bears" spec="RealScalarParam" domain="PositiveReal" value="1.0"/>
+        <stateNode id="ucldStdev.c:bears" spec="RealScalarParam" domain="PositiveReal" value="0.1"/>
+        <stateNode id="rateCategories.c:bears" spec="IntVectorParam" domain="NonNegativeInt" dimension="66" value="1"/>
         <stateNode id="originFBD.t:bears" spec="RealScalarParam" domain="PositiveReal" value="100.0"/>
         <stateNode id="diversificationRateFBD.t:bears" spec="RealScalarParam" domain="Real" value="1.0"/>
         <stateNode id="turnoverFBD.t:bears" spec="RealScalarParam" domain="UnitInterval" value="0.5"/>
         <stateNode id="samplingProportionFBD.t:bears" spec="RealScalarParam" domain="UnitInterval" value="0.5"/>
     </state>
 
-    <init id="RandomTree.t:bears" spec="beast.base.evolution.tree.coalescent.RandomTree" estimate="false" initial="@Tree.t:bears" taxa="@bears">
+    <init id="RandomTree.t:bears" spec="beast.base.spec.evolution.tree.coalescent.RandomTree" estimate="false" initial="@Tree.t:bears" taxa="@bears">
         <populationModel id="ConstantPopulation0.t:bears" spec="ConstantPopulation">
-            <parameter id="randomPopSize.t:bears" name="popSize">1.0</parameter>
+            <popSize id="randomPopSize.t:bears" spec="RealScalarParam" domain="PositiveReal" value="1.0"/>
         </populationModel>
     </init>
 
@@ -132,16 +122,14 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
             </distribution>
             <distribution id="samplingProportionPriorFBD.t:bears" spec="beast.base.spec.inference.distribution.Uniform" param="@samplingProportionFBD.t:bears"/>
             <distribution id="turnoverPriorFBD.t:bears" spec="beast.base.spec.inference.distribution.Uniform" param="@turnoverFBD.t:bears"/>
-            <prior id="MeanRatePrior.c:bears" name="distribution" x="@ucldMean.c:bears">
-                <Uniform id="Uniform.04" name="distr" upper="Infinity"/>
-            </prior>
-            <prior id="ucldStdevPrior.c:bears" name="distribution" x="@ucldStdev.c:bears">
-                <Gamma id="Gamma.0" name="distr">
-                    <parameter id="RealParameter.0" estimate="false" name="alpha">0.5396</parameter>
-                    <parameter id="RealParameter.01" estimate="false" name="beta">0.3819</parameter>
-                </Gamma>
-            </prior>
-            <distribution id="Canidae.prior" spec="beast.base.evolution.tree.MRCAPrior" monophyletic="true" tree="@Tree.t:bears">
+            <distribution id="MeanRatePrior.c:bears" spec="beast.base.spec.inference.distribution.Uniform" param="@ucldMean.c:bears">
+                <upper spec="RealScalarParam" domain="Real" value="10000.0" estimate="false"/>
+            </distribution>
+            <distribution id="ucldStdevPrior.c:bears" spec="beast.base.spec.inference.distribution.Gamma" param="@ucldStdev.c:bears">
+                <alpha spec="RealScalarParam" domain="PositiveReal" value="0.5396" estimate="false"/>
+                <beta spec="RealScalarParam" domain="PositiveReal" value="0.3819" estimate="false"/>
+            </distribution>
+            <distribution id="Canidae.prior" spec="beast.base.spec.evolution.tree.MRCAPrior" monophyletic="true" tree="@Tree.t:bears">
                 <taxonset id="Canidae" spec="TaxonSet">
                     <taxon id="Canis_lupus_0.0" spec="Taxon"/>
                     <taxon id="Caedocyon_tedfordi_25.88" spec="Taxon"/>
@@ -160,10 +148,10 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
                     <parameter id="proportionInvariant.s:bears" estimate="false" lower="0.0" name="proportionInvariant" upper="1.0">0.0</parameter>
                     <substModel id="JC69.s:bears" spec="JukesCantor"/>
                 </siteModel>
-                <branchRateModel id="RelaxedClock.c:bears" spec="beast.base.evolution.branchratemodel.UCRelaxedClockModel" clock.rate="@ucldMean.c:bears" rateCategories="@rateCategories.c:bears" tree="@Tree.t:bears">
-                    <LogNormal id="LogNormalDistributionModel.c:bears" S="@ucldStdev.c:bears" meanInRealSpace="true" name="distr">
-                        <parameter id="RealParameter.02" estimate="false" lower="0.0" name="M" upper="1.0">1.0</parameter>
-                    </LogNormal>
+                <branchRateModel id="RelaxedClock.c:bears" spec="beast.base.spec.evolution.branchratemodel.UCRelaxedClockModel" clock.rate="@ucldMean.c:bears" rateCategories="@rateCategories.c:bears" tree="@Tree.t:bears">
+                    <distribution id="LogNormalDistributionModel.c:bears" spec="beast.base.spec.inference.distribution.LogNormal" S="@ucldStdev.c:bears" meanInRealSpace="true" name="distr">
+                        <M spec="RealScalarParam" domain="Real" value="1.0" estimate="false"/>
+                    </distribution>
                 </branchRateModel>
             </distribution>
         </distribution>
@@ -177,7 +165,7 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
 
     <operator id="CategoriesSwapOperator.c:bears" spec="SwapOperator" intparameter="@rateCategories.c:bears" weight="10.0"/>
 
-    <operator id="CategoriesUniform.c:bears" spec="UniformOperator" parameter="@rateCategories.c:bears" weight="10.0"/>
+    <operator id="CategoriesUniform.c:bears" spec="beast.base.spec.inference.operator.uniform.IntUniformOperator" parameter="@rateCategories.c:bears" weight="10.0"/>
 
     <operator id="relaxedUpDownOperator.c:bears" spec="UpDownOperator" scaleFactor="0.75" weight="3.0">
         <up idref="ucldMean.c:bears"/>
@@ -250,7 +238,7 @@ Ursus_spelaeus_0.054=0.054                <taxa id="TaxonSet.bears" spec="TaxonS
     </logger>
 
     <logger id="treelog.t:bears" fileName="$(tree).trees" logEvery="1000" mode="tree">
-        <log id="TreeWithMetaDataLogger.t:bears" spec="beast.base.evolution.TreeWithMetaDataLogger" branchratemodel="@RelaxedClock.c:bears" tree="@Tree.t:bears"/>
+        <log id="TreeWithMetaDataLogger.t:bears" spec="beast.base.spec.evolution.TreeWithMetaDataLogger" branchratemodel="@RelaxedClock.c:bears" tree="@Tree.t:bears"/>
     </logger>
 
 </run>

--- a/examples/brachiopods.xml
+++ b/examples/brachiopods.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<beast beautitemplate="Standard" beautistatus="" namespace="beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.alignment:beast.base.evolution.tree.coalescent:beast.pkgmgmt:beast.base.core:beast.base.inference.util:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.base.spec.inference.parameter" required="SA v3.0.0:MM v1.3.0" version="2.5">
+<beast beautitemplate="Standard" beautistatus="" namespace="beast.pkgmgmt:beast.base.core:beast.base.inference:beast.base.evolution.alignment:beast.base.evolution.tree.coalescent:beast.pkgmgmt:beast.base.core:beast.base.inference.util:beast.evolution.nuc:beast.base.evolution.operator:beast.base.inference.operator:beast.base.evolution.sitemodel:beast.base.evolution.substitutionmodel:beast.base.evolution.likelihood:beast.base.spec.inference.parameter:beast.base.spec.domain" required="SA v3.0.0:MM v1.3.0" version="2.8">
   <data id="rode05_mod" dataType="standard" name="alignment">
     <sequence id="seq_Floweria_anomala" taxon="Floweria_anomala" totalcount="2" value="00{01}020111{01}11101110011100101111101010"/>
     <sequence id="seq_Floweria_arctostriata" taxon="Floweria_arctostriata" totalcount="2" value="1000{12}0{01}110{01}12100000{01}10011100100111{01}{01}"/>
@@ -58,16 +58,6 @@
       <charstatelabels id="UserDataType.35" spec="beast.base.evolution.datatype.UserDataType" characterName="character_36" codeMap="0=0, 1=1, ? =0 1 " states="2" value="state_0, state_1"/>
     </userDataType>
   </data>
-  <map name="Uniform">beast.base.inference.distribution.Uniform</map>
-  <map name="Exponential">beast.base.inference.distribution.Exponential</map>
-  <map name="LogNormal">beast.base.inference.distribution.LogNormalDistributionModel</map>
-  <map name="Normal">beast.base.inference.distribution.Normal</map>
-  <map name="Beta">beast.base.inference.distribution.Beta</map>
-  <map name="Gamma">beast.base.inference.distribution.Gamma</map>
-  <map name="LaplaceDistribution">beast.base.inference.distribution.LaplaceDistribution</map>
-  <map name="prior">beast.base.inference.distribution.Prior</map>
-  <map name="InverseGamma">beast.base.inference.distribution.InverseGamma</map>
-  <map name="OneOnX">beast.base.inference.distribution.OneOnX</map>
   <run id="mcmc" spec="MCMC" chainLength="100000000">
     <state id="state" storeEvery="50000">
       <tree id="Tree.t:rode05_mod" name="stateNode">
@@ -102,11 +92,11 @@ Xystostrophia_umbraculum=0<taxa id="TaxonSet.rode05_mod" spec="TaxonSet"><alignm
       <stateNode id="turnoverFBD.t:rode05_mod" spec="RealScalarParam" domain="UnitInterval" value="0.5"/>
       <stateNode id="samplingProportionFBD.t:rode05_mod" spec="RealScalarParam" domain="UnitInterval" value="0.5"/>
       <stateNode id="originFBD.t:rode05_mod" spec="RealScalarParam" domain="PositiveReal" value="500.0"/>
-      <parameter id="clockRate.c:rode05_mod" name="stateNode">1.0</parameter>
+      <stateNode id="clockRate.c:rode05_mod" spec="RealScalarParam" domain="PositiveReal" value="1.0"/>
     </state>
-    <init id="RandomTree.t:rode05_mod" spec="beast.base.evolution.tree.coalescent.RandomTree" estimate="false" initial="@Tree.t:rode05_mod" taxa="@rode05_mod">
+    <init id="RandomTree.t:rode05_mod" spec="beast.base.spec.evolution.tree.coalescent.RandomTree" estimate="false" initial="@Tree.t:rode05_mod" taxa="@rode05_mod">
       <populationModel id="ConstantPopulation0.t:rode05_mod" spec="ConstantPopulation">
-        <parameter id="randomPopSize.t:rode05_mod" name="popSize">1.0</parameter>
+        <popSize id="randomPopSize.t:rode05_mod" spec="RealScalarParam" domain="PositiveReal" value="1.0"/>
       </populationModel>
     </init>
     <distribution id="posterior" spec="beast.base.inference.CompoundDistribution">
@@ -116,12 +106,10 @@ Xystostrophia_umbraculum=0<taxa id="TaxonSet.rode05_mod" spec="TaxonSet"><alignm
           <rho id="rhoFBD.t:rode05_mod" spec="RealScalarParam" domain="UnitInterval" value="1.0" estimate="false"/>
           <treeWOffset id="treeWoffset" spec="sa.evolution.tree.TreeWOffset" tree="@Tree.t:rode05_mod" offset="367.762481269822"/>
         </distribution>
-        <prior id="ClockPrior.c:rode05_mod" name="distribution" x="@clockRate.c:rode05_mod">
-          <LogNormal id="LogNormalDistributionModel.1" meanInRealSpace="true" name="distr">
-            <parameter id="RealParameter.3" estimate="false" name="M">0.2</parameter>
-            <parameter id="Real.Parameter.4" estimate="false" lower="0.0" name="S" upper="5.0">1.25</parameter>
-          </LogNormal>
-        </prior>
+        <distribution id="ClockPrior.c:rode05_mod" spec="beast.base.spec.inference.distribution.LogNormal" param="@clockRate.c:rode05_mod" meanInRealSpace="true">
+          <M spec="RealScalarParam" domain="Real" value="0.2" estimate="false"/>
+          <S spec="RealScalarParam" domain="PositiveReal" value="1.25" estimate="false"/>
+        </distribution>
         <distribution id="diversificationRatePriorFBD.t:rode05_mod" spec="beast.base.spec.inference.distribution.Uniform" param="@diversificationRateFBD.t:rode05_mod">
           <upper spec="RealScalarParam" domain="Real" value="10000.0" estimate="false"/>
         </distribution>
@@ -138,7 +126,7 @@ Xystostrophia_umbraculum=0<taxa id="TaxonSet.rode05_mod" spec="TaxonSet"><alignm
             <parameter id="gammaShape.s:rode05_mod" estimate="false" name="shape">1.0</parameter>
             <substModel id="LewisMK.s:rode05_mod" spec="morphmodels.evolution.substitutionmodel.LewisMK" datatype="@StandardData"/>
           </siteModel>
-          <branchRateModel id="StrictClock.c:rode05_mod" spec="beast.base.evolution.branchratemodel.StrictClockModel" clock.rate="@clockRate.c:rode05_mod"/>
+          <branchRateModel id="StrictClock.c:rode05_mod" spec="beast.base.spec.evolution.branchratemodel.StrictClockModel" clock.rate="@clockRate.c:rode05_mod"/>
         </distribution>
       </distribution>
     </distribution>
@@ -180,7 +168,7 @@ Xystostrophia_umbraculum=0<taxa id="TaxonSet.rode05_mod" spec="TaxonSet"><alignm
       <log idref="prior"/>
     </logger>
     <logger id="treelog.t:rode05_mod" fileName="brachiopods_FBD_interval_ages.trees" logEvery="10000" mode="tree">
-      <log id="TreeWithMetaDataLogger.t:rode05_mod" spec="beast.base.evolution.TreeWithMetaDataLogger" tree="@Tree.t:rode05_mod"/>
+      <log id="TreeWithMetaDataLogger.t:rode05_mod" spec="beast.base.spec.evolution.TreeWithMetaDataLogger" tree="@Tree.t:rode05_mod"/>
     </logger>
     <operator spec="sa.evolution.operators.SampledNodeDateRandomWalker" windowSize="10." tree="@Tree.t:rode05_mod" treeWOffset="@treeWoffset" weight="5.">
       <samplingDates id="samplingDate.Floweria_anomala1" spec="sa.evolution.tree.SamplingDate" taxon="@Floweria_anomala" lower="382.7" upper="387.7"/>


### PR DESCRIPTION
## Summary

Migrate the three example XMLs onto BEAST 3 spec types, the follow-up flagged by [PR #27](https://github.com/CompEvol/sampled-ancestors/pull/27).

The same pattern was applied to each file:

- Bump `version="2.8"` and add `beast.base.spec.domain` to the namespace.
- Drop the legacy `<map>` block (distribution short names are no longer used; spec distributions are referenced directly by FQN).
- Convert `<parameter id=… name="stateNode">value</parameter>` declarations to `<stateNode spec="RealScalarParam" domain="…">` (or `IntVectorParam` + `NonNegativeInt` for `rateCategories.c:bears`).
- Rewrite `<prior name="distribution" x="@param">…<Uniform/Gamma/LogNormal/></prior>` wrappers as direct spec distributions with `param="@param"`. Spec distributions are themselves priors; the wrapper is gone.
- Swap deprecated `spec=` FQNs:
  - `beast.base.evolution.tree.coalescent.RandomTree` → `beast.base.spec.evolution.tree.coalescent.RandomTree`
  - `beast.base.evolution.tree.MRCAPrior` → `beast.base.spec.evolution.tree.MRCAPrior` (bears only)
  - `beast.base.evolution.branchratemodel.UCRelaxedClockModel` → `beast.base.spec.evolution.branchratemodel.UCRelaxedClockModel` (bears only)
  - `beast.base.evolution.branchratemodel.StrictClockModel` → `beast.base.spec.evolution.branchratemodel.StrictClockModel` (brachiopods only)
  - `beast.base.evolution.TreeWithMetaDataLogger` → `beast.base.spec.evolution.TreeWithMetaDataLogger`
  - `UniformOperator` on integer `rateCategories` → `beast.base.spec.inference.operator.uniform.IntUniformOperator` (bears only)

After the change, [beast3-migration](https://github.com/CompEvol/beast3-migration) reports sampled-ancestors as `🟢 / 🟢 / 🟢 ✅` (Code / XML / FxT) with no deprecated class references.

## Test plan

- [x] Migration linter clean across all three examples after the change.
- [ ] Smoke-test each example end-to-end — I have NOT run BEAST against the migrated XMLs. Mechanical changes only, mirroring the patterns already used in the Maven Central-published examples elsewhere in the repo, but worth running once before merging.
